### PR TITLE
Vberenz/install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,14 +3,6 @@ cmake_minimum_required(VERSION 3.10.2)
 project(mujoco_interface)
 
 
-# TODO
-# clean this up. Too much hard-coded
-# commands here.
-# all this assumes mujoco has been unzipped
-# in /opt/mpi-is/mujoco200_linux
-# (as opposed as the usual location:
-#  /home/user/.mujoco)
-#
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
@@ -33,43 +25,20 @@ set(all_target_exports)
 # Mujoco libraries #
 ####################
 
-# it is assumed mujoco has been unzipped in
-# /opt/mpi-is/mujoco200_linux (deprecated) or /usr/local/mujoco200_linux
-if (EXISTS "/opt/mpi-is/mujoco200_linux")
-  set(mujoco_lib_dir "/opt/mpi-is/mujoco200_linux/bin")
-  set(mujoco_include_dir "/opt/mpi-is/mujoco200_linux/include")
-elseif (EXISTS "/usr/local/mujoco200_linux")
-  set(mujoco_lib_dir "/usr/local/mujoco200_linux/bin")
-  set(mujoco_include_dir "/usr/local/mujoco200_linux/include")
-else()
-  message(ERROR "failed to find /usr/local/mujoco200_linux or /opt/mpi-is/mujoco200_linux")
-endif()
-set(mujoco_libs)
-list(APPEND mujoco_libs "libglew.so")
-list(APPEND mujoco_libs "libglewegl.so")
-list(APPEND mujoco_libs "libglfw.so.3")
-list(APPEND mujoco_libs "libmujoco200.so")
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/mujoco_libs.cmake)
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/cmake/
+        DESTINATION share/${PROJECT_NAME}/cmake)
+ADD_MUJOCO_LIBS() # from mujoco_libs.cmake
 
-if(NOT EXISTS ${mujoco_include_dir})
-  message(FATAL_ERROR "failed to find ${mujoco_include_dir}")
-endif()
 
-if(NOT EXISTS ${mujoco_lib_dir})
-  message(FATAL_ERROR "failed to find ${mujoco_lib_dir}")
-endif()
+###########
+# Library #
+###########
 
-foreach(mujoco_lib ${mujoco_libs})
-  if(NOT EXISTS ${mujoco_lib_dir}/${mujoco_lib})
-    message(FATAL_ERROR "failed to find ${mujoco_lib_dir}/${mujoco_lib}")
-  endif()
-endforeach(mujoco_lib)
-
-add_library(${PROJECT_NAME} SHARED ${mujoco_include_dir}/uitools.c)
+add_library(${PROJECT_NAME} SHARED ${mujoco_sample_dir}/uitools.c)
 target_include_directories(
-  ${PROJECT_NAME} PUBLIC ${mujoco_include_dir} )
-foreach(mujoco_lib ${mujoco_libs})
-  target_link_libraries(${PROJECT_NAME} ${mujoco_lib_dir}/${mujoco_lib})
-endforeach(mujoco_lib)
+  ${PROJECT_NAME} PUBLIC ${mujoco_include_dir} ${mujoco_sample_dir} )
+LINK_AGAINST_MUJOCO(${PROJECT_NAME}) # from mujoco_libs.cmake
 target_link_libraries(${PROJECT_NAME} -lpthread -lm)
 ament_export_interfaces(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 list(APPEND all_targets ${PROJECT_NAME})
@@ -89,3 +58,4 @@ install(
   INCLUDES
   DESTINATION)
 ament_package()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,17 +2,16 @@ cmake_minimum_required(VERSION 3.10.2)
 
 project(mujoco_interface)
 
-
-
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
-
 
 ################
 # Dependencies #
 ################
 
 find_package(ament_cmake REQUIRED)
+find_package(cmake_always_do REQUIRED)
+find_package(glfw3 REQUIRED)
 
 ament_export_dependencies()
 
@@ -20,16 +19,22 @@ ament_export_dependencies()
 set(all_targets)
 set(all_target_exports)
 
+#####################
+# Installing Mujoco #
+#####################
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/install_mujoco.cmake)
+INSTALL_MUJOCO()
 
 ####################
 # Mujoco libraries #
 ####################
 
+# the macro for linking to the libaries
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/mujoco_libs.cmake)
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/cmake/
         DESTINATION share/${PROJECT_NAME}/cmake)
 ADD_MUJOCO_LIBS() # from mujoco_libs.cmake
-
 
 ###########
 # Library #
@@ -40,10 +45,10 @@ target_include_directories(
   ${PROJECT_NAME} PUBLIC ${mujoco_include_dir} ${mujoco_sample_dir} )
 LINK_AGAINST_MUJOCO(${PROJECT_NAME}) # from mujoco_libs.cmake
 target_link_libraries(${PROJECT_NAME} -lpthread -lm)
+target_link_libraries(${PROJECT_NAME} glfw)
 ament_export_interfaces(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 list(APPEND all_targets ${PROJECT_NAME})
 list(APPEND all_target_exports export_${PROJECT_NAME})
-
 
 ######################
 # Install and export #
@@ -57,5 +62,6 @@ install(
   RUNTIME DESTINATION bin
   INCLUDES
   DESTINATION)
-ament_package()
+
+ament_package(CONFIG_EXTRAS ${CMAKE_CURRENT_SOURCE_DIR}/cmake/mujoco_libs.cmake)
 

--- a/cmake/install_mujoco.cmake
+++ b/cmake/install_mujoco.cmake
@@ -2,30 +2,35 @@
 
 macro(INSTALL_MUJOCO)
 
-  # installing if not installed
-  # todo: should message with STATUS mode, but then
-  # nothing shows up in the terminal. Using INFO for now
-  # (but print to stderr)
-  set(local_mujoco "$ENV{HOME}/.mpi-is/mujoco")
-  message(INFO " installing mujoco in ${local_mujoco}")
-  if (NOT EXISTS ${local_mujoco})
     execute_process(
-      COMMAND bash -c "${CMAKE_CURRENT_SOURCE_DIR}/install"
-      OUTPUT_VARIABLE mujoco_install_stdout
-      RESULT_VARIABLE mujoco_install_exit_code)
-    if (mujoco_install_exit_code EQUAL "1")
-      message(ERROR " failed to install mujoco with stdout:\n${mujoco_install_stdout}\n")
-    else ()
-      message(INFO " installed mujoco")
-    endif ()
-  else ()
-    message(INFO " mujoco already installed in ${local_mujoco}, skipping")
-  endif ()
+      COMMAND bash -c "${CMAKE_CURRENT_SOURCE_DIR}/install_folder"
+      OUTPUT_VARIABLE install_folder
+      ERROR_VARIABLE install_folder_stderr
+      RESULT_VARIABLE install_folder_exit_code)
 
-  # from cmake_always_do/cmake/always_do.cmake
-  # ensure this macro will be called everytime 'colcon build'
-  # is called (even despite the cache)
-  ALWAYS_DO("installing mujoco") 
-  
+    if(NOT install_folder_exit_code EQUAL "0")
+      message(ERROR " failed to determine mujoco installation location: ${install_folder_stderr}")
+    endif()
+    
+    message(INFO " installing mujoco in ${install_folder}")
+    if (NOT EXISTS "${install_folder}")
+      execute_process(
+	COMMAND bash -c "${CMAKE_CURRENT_SOURCE_DIR}/install"
+	OUTPUT_VARIABLE mujoco_install_stdout
+	RESULT_VARIABLE mujoco_install_exit_code)
+      if (NOT mujoco_install_exit_code EQUAL "0")
+	message(ERROR " failed to install mujoco with stdout:\n${mujoco_install_stdout}\n")
+      else ()
+	message(INFO " installed mujoco")
+      endif ()
+    else ()
+      message(INFO " mujoco already installed in ${install_folder}, skipping")
+    endif ()
+    
+    # from cmake_always_do/cmake/always_do.cmake
+    # ensure this macro will be called everytime 'colcon build'
+    # is called (even despite the cache)
+    ALWAYS_DO("installing mujoco") 
+    
 endmacro()
 

--- a/cmake/install_mujoco.cmake
+++ b/cmake/install_mujoco.cmake
@@ -1,0 +1,31 @@
+
+
+macro(INSTALL_MUJOCO)
+
+  # installing if not installed
+  # todo: should message with STATUS mode, but then
+  # nothing shows up in the terminal. Using INFO for now
+  # (but print to stderr)
+  set(local_mujoco "$ENV{HOME}/.mpi-is/mujoco")
+  message(INFO " installing mujoco in ${local_mujoco}")
+  if (NOT EXISTS ${local_mujoco})
+    execute_process(
+      COMMAND bash -c "${CMAKE_CURRENT_SOURCE_DIR}/install"
+      OUTPUT_VARIABLE mujoco_install_stdout
+      RESULT_VARIABLE mujoco_install_exit_code)
+    if (mujoco_install_exit_code EQUAL "1")
+      message(ERROR " failed to install mujoco with stdout:\n${mujoco_install_stdout}\n")
+    else ()
+      message(INFO " installed mujoco")
+    endif ()
+  else ()
+    message(INFO " mujoco already installed in ${local_mujoco}, skipping")
+  endif ()
+
+  # from cmake_always_do/cmake/always_do.cmake
+  # ensure this macro will be called everytime 'colcon build'
+  # is called (even despite the cache)
+  ALWAYS_DO("installing mujoco") 
+  
+endmacro()
+

--- a/cmake/mujoco_libs.cmake
+++ b/cmake/mujoco_libs.cmake
@@ -1,0 +1,73 @@
+# This file assumes the install executable (same folder)
+# has been called, i.e. mujoco is installed in either
+# ~/.mpi-is/mujoco or /opt/mpi-is/mujoco
+
+
+# 1. set these variables:
+# mujoco_dir (to either ~/.mpi-is/mujoco or /opt/mpi-is/mujoco
+# mujoco_lib_dir (${mujoco_dir}/lib)
+# mujoco_include_dir (${mujoco_dir}/include)
+# mujoco_sample_dir (${mujoco_dir}/sample)
+# mujoco_libs (libglew.so, libglewegl.so, libmujoco.so)
+# 2. add the mujoco_libs (expected to be found in 
+# ${mujoco_lib_dir}
+macro(ADD_MUJOCO_LIBS)
+  
+  set(local_mujoco "~/.mpi-is/mujoco")
+  set(global_mujoco "/opt/mpi-is/mujoco")
+  
+  # checking mujoco has been installed
+  if (EXISTS ${local_mujoco})
+    set(mujoco_dir ${local_mujoco})
+  elseif(EXISTS ${global_mujoco})
+    set(mujoco_dir ${global_mujoco})
+  else()
+    message(ERROR "failed to find ${local_mujoco} nor ${global_mujoco}")
+  endif()
+
+  # checking all expected sub-directories are there
+  set(mujoco_lib_dir "${mujoco_dir}/lib")
+  set(mujoco_include_dir "${mujoco_dir}/include")
+  set(mujoco_sample_dir "${mujoco_dir}/sample")
+  if(NOT EXISTS ${mujoco_include_dir})
+    message(FATAL_ERROR "failed to find ${mujoco_include_dir}")
+  endif()
+  if(NOT EXISTS ${mujoco_lib_dir})
+    message(FATAL_ERROR "failed to find ${mujoco_lib_dir}")
+  endif()
+  if(NOT EXISTS ${mujoco_sample_dir})
+    message(FATAL_ERROR "failed to find ${mujoco_sample_dir}")
+  endif()
+
+  # we need these libraries provided by mujoco and expected
+  # in the lib folder
+  list(APPEND mujoco_libs "libglew.so")
+  list(APPEND mujoco_libs "libglewegl.so")
+  list(APPEND mujoco_libs "libmujoco.so")
+  foreach(mujoco_lib ${mujoco_libs})
+    if(NOT EXISTS ${mujoco_lib_dir}/${mujoco_lib})
+      message(FATAL_ERROR "failed to find ${mujoco_lib_dir}/${mujoco_lib}")
+    endif()
+  endforeach(mujoco_lib)
+
+  # adding the libraries to the current project
+  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE) # keeping linkage during installation
+  foreach(mujoco_lib ${mujoco_libs})
+    add_library(${mujoco_lib} SHARED IMPORTED)
+    set_target_properties( ${mujoco_lib} PROPERTIES IMPORTED_LOCATION ${mujoco_lib_dir}/${mujoco_lib})
+    ament_export_libraries(${mujoco_lib})
+  endforeach(mujoco_lib)
+
+endmacro(ADD_MUJOCO_LIBS)
+
+
+# Link the target against all mujoco libraries
+# ($mujoco_libs as set by a call to the add_mujoco_libs macro,
+#  located in this file)
+macro(LINK_AGAINST_MUJOCO target_name)
+
+  foreach(mujoco_lib ${mujoco_libs})
+    target_link_libraries(${target_name} ${mujoco_lib})
+  endforeach(mujoco_lib)
+  
+endmacro(LINK_AGAINST_MUJOCO)

--- a/cmake/mujoco_libs.cmake
+++ b/cmake/mujoco_libs.cmake
@@ -41,8 +41,6 @@ macro(ADD_MUJOCO_LIBS)
 
   # we need these libraries provided by mujoco and expected
   # in the lib folder
-  #list(APPEND mujoco_libs "libglew.so")
-  #list(APPEND mujoco_libs "libglewegl.so")
   list(APPEND mujoco_libs "libmujoco.so")
   foreach(mujoco_lib ${mujoco_libs})
     if(NOT EXISTS ${mujoco_lib_dir}/${mujoco_lib})

--- a/cmake/mujoco_libs.cmake
+++ b/cmake/mujoco_libs.cmake
@@ -13,7 +13,7 @@
 # ${mujoco_lib_dir}
 macro(ADD_MUJOCO_LIBS)
   
-  set(local_mujoco "~/.mpi-is/mujoco")
+  set(local_mujoco "$ENV{HOME}/.mpi-is/mujoco")
   set(global_mujoco "/opt/mpi-is/mujoco")
   
   # checking mujoco has been installed
@@ -41,8 +41,8 @@ macro(ADD_MUJOCO_LIBS)
 
   # we need these libraries provided by mujoco and expected
   # in the lib folder
-  list(APPEND mujoco_libs "libglew.so")
-  list(APPEND mujoco_libs "libglewegl.so")
+  #list(APPEND mujoco_libs "libglew.so")
+  #list(APPEND mujoco_libs "libglewegl.so")
   list(APPEND mujoco_libs "libmujoco.so")
   foreach(mujoco_lib ${mujoco_libs})
     if(NOT EXISTS ${mujoco_lib_dir}/${mujoco_lib})

--- a/install
+++ b/install
@@ -32,7 +32,7 @@ cd $INSTALL_DIR
 rm -rf $INSTALL_DIR/*
 
 # downloading mujoco
-wget https://github.com/deepmind/mujoco/releases/download/2.1.1/mujoco-${MUJOCO_VERSION}-linux-x86_64.tar.gz
+wget https://github.com/deepmind/mujoco/releases/download/${MUJOCO_VERSION}/mujoco-${MUJOCO_VERSION}-linux-x86_64.tar.gz
 
 # uncompressing
 tar -zxvf ./mujoco-${MUJOCO_VERSION}-linux-x86_64.tar.gz
@@ -47,3 +47,5 @@ rm ./mujoco-${MUJOCO_VERSION}-linux-x86_64.tar.gz
 
 # giving read and execute rights to everbody
 chmod -R 755 $INSTALL_DIR
+
+exit 0

--- a/install
+++ b/install
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+MUJOCO_VERSION=2.1.1
+
+# exit at first error
+set -e
+
+# where config folders will be copied
+GLOBAL_INSTALL=/opt/mpi-is/mujoco # if install called by root
+USER_INSTALL=$HOME/.mpi-is/mujoco # if install called by someone else
+
+# not same installation folder if script called
+# with or without sudo
+if [ "$EUID" -ne 0 ]
+then
+   # without sudo: user home directory
+   INSTALL_DIR=$USER_INSTALL
+   echo "installing configuration file in $INSTALL_DIR"
+else
+   # with sudo: global install
+   INSTALL_DIR=$GLOBAL_INSTALL
+   echo "sudo: installing configuration file in $INSTALL_DIR"
+fi
+
+# creating the install folder
+mkdir -p $INSTALL_DIR
+
+# going to install dir
+cd $INSTALL_DIR
+
+# removing existing content
+rm -rf $INSTALL_DIR/*
+
+# downloading mujoco
+wget https://github.com/deepmind/mujoco/releases/download/2.1.1/mujoco-${MUJOCO_VERSION}-linux-x86_64.tar.gz
+
+# uncompressing
+tar -zxvf ./mujoco-${MUJOCO_VERSION}-linux-x86_64.tar.gz
+
+# moving from ./mujoco-{version} to ./
+# (so that the folder remains the same
+#  over various versions)
+mv ./mujoco-${MUJOCO_VERSION}/* ./ && rmdir ./mujoco-${MUJOCO_VERSION}
+
+# deleting tar file
+rm ./mujoco-${MUJOCO_VERSION}-linux-x86_64.tar.gz
+
+# giving read and execute rights to everbody
+chmod -R 755 $INSTALL_DIR

--- a/install
+++ b/install
@@ -5,22 +5,14 @@ MUJOCO_VERSION=2.1.1
 # exit at first error
 set -e
 
-# where config folders will be copied
-GLOBAL_INSTALL=/opt/mpi-is/mujoco # if install called by root
-USER_INSTALL=$HOME/.mpi-is/mujoco # if install called by someone else
+# folder where this script is
+script_dir=$(dirname "$0")
 
-# not same installation folder if script called
-# with or without sudo
-if [ "$EUID" -ne 0 ]
-then
-   # without sudo: user home directory
-   INSTALL_DIR=$USER_INSTALL
-   echo "installing configuration file in $INSTALL_DIR"
-else
-   # with sudo: global install
-   INSTALL_DIR=$GLOBAL_INSTALL
-   echo "sudo: installing configuration file in $INSTALL_DIR"
-fi
+# calling the install_folder script
+# (same directory) to get the folder
+# where mujoco should be installed.
+INSTALL_DIR=$($script_dir/install_folder)
+echo "installing mujoco in ${INSTALL_DIR}"
 
 # creating the install folder
 mkdir -p $INSTALL_DIR
@@ -35,7 +27,7 @@ rm -rf $INSTALL_DIR/*
 wget https://github.com/deepmind/mujoco/releases/download/${MUJOCO_VERSION}/mujoco-${MUJOCO_VERSION}-linux-x86_64.tar.gz
 
 # uncompressing
-tar -zxvf ./mujoco-${MUJOCO_VERSION}-linux-x86_64.tar.gz
+tar --no-same-owner -zxvf ./mujoco-${MUJOCO_VERSION}-linux-x86_64.tar.gz
 
 # moving from ./mujoco-{version} to ./
 # (so that the folder remains the same

--- a/install_folder
+++ b/install_folder
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# prints in the terminal the installation folder
+# of mujoco (depending on whether or not the install
+# scripts has been called by root
+
+# where config folders will be copied
+GLOBAL_INSTALL=/opt/mpi-is/mujoco # if install called by root
+USER_INSTALL=$HOME/.mpi-is/mujoco # if install called by someone else
+
+# not same installation folder if script called
+# with or without sudo
+if [ "$EUID" -ne 0 ]
+then
+   # without sudo: user home directory
+   INSTALL_DIR=$USER_INSTALL
+else
+   # with sudo: global install
+   INSTALL_DIR=$GLOBAL_INSTALL
+fi
+
+echo -n "${INSTALL_DIR}"
+
+exit 0

--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,8 @@
   <license>BSD 3-Clause</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
+  <buildtool_depend>cmake_always_do</buildtool_depend>
+  
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,7 @@
   <license>BSD 3-Clause</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>cmake_always_do</buildtool_depend>
+  <build_depend>cmake_always_do</build_depend>
   
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description
- Mujoco is now downloaded and installed to ~/.mpi-is/mujoco during built time (only if not already present). This simplifies installation (user no longer need to download and install mujoco themselves)
- some Macro for linking to the mujoco libraries are exported

## How I Tested

Compiled and run on my machine

